### PR TITLE
fixed requirements for triangle assignment

### DIFF
--- a/src/exercism_io/core.clj
+++ b/src/exercism_io/core.clj
@@ -507,7 +507,7 @@
                                              (p "An " (italic "isosceles") " triangle has at least two sides the same length. (It is sometimes specified as having exactly two sides the same length, but for the purposes of this exercise we'll say at least two.)")
                                              (p "A " (italic "scalene") " triangle has all sides of different lengths.")
 
-                                             (p "For a shape to be a triangle at all, all sides have to be of length > 0, and the sum of the lengths of any two sides must be greater than or equal to the length of the third side. See " (link "Triangle Inequality" "https://en.wikipedia.org/wiki/Triangle_inequality") ".")))
+                                             (p "For a shape to be a triangle at all, all sides have to be of length > 0, and the sum of the lengths of any two sides must be greater than the length of the third side. See " (link "Triangle Inequality" "https://en.wikipedia.org/wiki/Triangle_inequality") ".")))
 
                                          (instruction 'ins-triangle
                                                       (run-pre-tests? true)


### PR DESCRIPTION
problem stated that a valid triangle was if the sum of two sides was greater than or equal two the third side which is incorrect, the sum of two sides must be greater than the third.
even the test cases check this logic by saying (triangle-type 1 2 1) is illogical instead of isosceles